### PR TITLE
启动延时过短，可能会触发‘没有找到进程为nikke.exe的窗口，初始化失败’

### DIFF
--- a/DoroHelper.ahk
+++ b/DoroHelper.ahk
@@ -1088,7 +1088,7 @@ AutoStartNikke() {
                 ; 检查游戏是否已经启动
                 if ProcessExist(gameExe) {
                     AddLog("检测到游戏进程 " gameExe " 已启动，停止点击")
-                    Sleep 5000 ; 等待游戏稳定
+                    Sleep 10000 ; 等待游戏稳定
                     break 2 ; 跳出两层循环
                 }
                 ; 执行点击启动按钮


### PR DESCRIPTION
在ClickOnDoro()函数调用了AutoStartNikke()函数于nikke launcher界面点击了启动游戏之后，到调用Initialization之间，只有这么5秒延迟，对于低配置电脑不太够。

在一台配置为9950x3d+5090的电脑上，原本的5秒延迟可以正常启动游戏；而在一台配置为5900x+2080的电脑上，会触发以下报错：

<img width="1499" height="376" alt="Snipaste_2025-09-11_18-45-33" src="https://github.com/user-attachments/assets/699fb653-9b57-4b3c-93d3-445625b14a83" />
