### PR TITLE
fix: 禁用压缩以避免杀毒软件误报

### DIFF
--- a/.github/workflows/Compile AHK 2.0 and Release.yml
+++ b/.github/workflows/Compile AHK 2.0 and Release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version_override:
-        description: "Override version from AHK script (e.g., v1.0.0)"
+        description: 'Override version from AHK script (e.g., v1.0.0)'
         required: false
         type: string
 
@@ -162,6 +162,8 @@ jobs:
           icon: ./doro.ico
           target: x64
           ahk-tag: v2.0.19
+          # 关闭压缩以避免杀毒软件误报（等效于 Ahk2Exe 的 "/compress 0"）
+          compression: none
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub Release


### PR DESCRIPTION
禁用 UPX 压缩以降低杀毒软件误报率
本次提交在 AHK 编译阶段禁用了 UPX 压缩（使用 <code inline="">/compress 0</code>），以减少可执行文件被杀毒软件误报为木马的情况。
<h3>背景说明</h3>
<p>部分杀毒软件会对使用 UPX 压缩的可执行文件给出较高的风险评分，容易触发启发式或机器学习误报。关闭压缩后，EXE 文件结构更透明，有利于安全软件进行正常分析。</p>
<h3>调整效果</h3>
<p>经 VirusTotal 测试：</p>

构建方式 | 报毒率
-- | --
原版本（启用 UPX） | 10 / 71
当前版本（无压缩） | 2 / 71


<p>误报率显著下降，仅剩个别小厂引擎误报。</p>
关联 issue：1204244136/DoroHelper#53
