### PR TITLE
fix: 修复 README 星标历程图

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Hanpass|PandaRemit|WireBarley|GmoneyTrans|Debunk|PayForex|koala transfer|Sendly|
 
 ## 星标历程
 
-[![Star History Chart](https://api.star-history.com/svg?repos=1204244136/DoroHelper&type=Timeline)](https://www.star-history.com/#1204244136/DoroHelper&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=1204244136/DoroHelper&type=Timeline)](https://star-history.dera.page/#1204244136/DoroHelper&Timeline)
 
 ## 借物表
 

--- a/README_en.md
+++ b/README_en.md
@@ -219,7 +219,7 @@ Hanpass|PandaRemit|WireBarley|GmoneyTrans|Debunk|PayForex|koala transfer|Sendly|
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=1204244136/DoroHelper&type=Timeline)](https://www.star-history.com/#1204244136/DoroHelper&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=1204244136/DoroHelper&type=Timeline)](https://star-history.dera.page/#1204244136/DoroHelper&Timeline)
 
 ## Credits
 


### PR DESCRIPTION
当前 README 中的 Star History 图表已失效，原因是上游数据接口受到限制。本 PR 将图表更新为可用的替代数据源，无需任何 API 令牌即可正常加载，让星标历程恢复显示。